### PR TITLE
Box<T> buffers in StrandReader / Writer

### DIFF
--- a/src/buffer/block.rs
+++ b/src/buffer/block.rs
@@ -20,8 +20,9 @@
  */
 
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
-use super::TRIM_SIZE;
+use super::{TRIM_SIZE, ByteArray};
 
 #[derive(Clone)]
 pub struct Block([u8; TRIM_SIZE]);
@@ -52,8 +53,16 @@ impl AsRef<[u8]> for Block {
     }
 }
 
+impl Hash for Block {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&self.0[..]);
+    }
+}
+
 impl fmt::Debug for Block {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Block: {:?}..", &self.0[..16])
     }
 }
+
+impl ByteArray for Block {}

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -1,5 +1,5 @@
 /*
- * buffer/mod.rs
+ * buffer/buffer.rs
  *
  * striking-db - Persistent key/value store for SSDs.
  * Copyright (c) 2017 Maxwell Duzen, Ammon Smith
@@ -19,21 +19,43 @@
  *
  */
 
-mod block;
-mod buffer;
-mod page;
-mod traits;
+use std::ops::{Deref, DerefMut};
+use super::{ByteArray, BufferStatus};
 
-use super::{PAGE_SIZE, TRIM_SIZE};
+#[derive(Debug, Clone, Hash)]
+pub struct Buffer<B: ByteArray> {
+    bytes: B,
+    status: BufferStatus,
+    cursor: u64,
+}
 
-pub use self::block::Block;
-pub use self::buffer::Buffer;
-pub use self::page::Page;
-pub use self::traits::ByteArray;
+impl<B: ByteArray> Buffer<B> {
+    pub fn new() -> Self {
+        Buffer {
+            bytes: B::default(),
+            status: BufferStatus::Empty,
+            cursor: 0,
+        }
+    }
+}
 
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
-pub enum BufferStatus {
-    Clean,
-    Dirty,
-    Empty,
+impl<B: ByteArray> Deref for Buffer<B> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &*self.bytes
+    }
+}
+
+impl<B: ByteArray> DerefMut for Buffer<B> {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut *self.bytes
+    }
+}
+
+impl<B: ByteArray> Default for Buffer<B> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -19,14 +19,14 @@
  *
  */
 
+use std::cmp::min;
 use std::ops::{Deref, DerefMut};
 use super::{ByteArray, BufferStatus};
 
 #[derive(Debug, Clone, Hash)]
 pub struct Buffer<B: ByteArray> {
-    bytes: B,
-    status: BufferStatus,
-    cursor: u64,
+    pub bytes: B,
+    pub status: BufferStatus,
 }
 
 impl<B: ByteArray> Buffer<B> {
@@ -34,8 +34,11 @@ impl<B: ByteArray> Buffer<B> {
         Buffer {
             bytes: B::default(),
             status: BufferStatus::Empty,
-            cursor: 0,
         }
+    }
+
+    pub fn reset(&mut self) {
+        self.status = BufferStatus::Empty;
     }
 }
 

--- a/src/buffer/page.rs
+++ b/src/buffer/page.rs
@@ -22,7 +22,7 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
-use super::PAGE_SIZE;
+use super::{PAGE_SIZE, ByteArray};
 
 #[derive(Clone)]
 pub struct Page([u8; PAGE_SIZE]);
@@ -64,3 +64,5 @@ impl fmt::Debug for Page {
         write!(f, "Page: {:?}..", &self.0[..16])
     }
 }
+
+impl ByteArray for Page {}

--- a/src/buffer/traits.rs
+++ b/src/buffer/traits.rs
@@ -21,6 +21,11 @@
 
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 
-pub trait ByteArray: Default + Debug + Clone + Hash + DerefMut<Target = [u8]> {}
+pub trait ByteArray
+where
+    Self: DerefMut<Target = [u8]>,
+    Self: Default + Debug + Clone + Hash
+{
+}

--- a/src/buffer/traits.rs
+++ b/src/buffer/traits.rs
@@ -1,5 +1,5 @@
 /*
- * buffer/mod.rs
+ * buffer/traits.rs
  *
  * striking-db - Persistent key/value store for SSDs.
  * Copyright (c) 2017 Maxwell Duzen, Ammon Smith
@@ -19,21 +19,8 @@
  *
  */
 
-mod block;
-mod buffer;
-mod page;
-mod traits;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::ops::{Deref, DerefMut};
 
-use super::{PAGE_SIZE, TRIM_SIZE};
-
-pub use self::block::Block;
-pub use self::buffer::Buffer;
-pub use self::page::Page;
-pub use self::traits::ByteArray;
-
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
-pub enum BufferStatus {
-    Clean,
-    Dirty,
-    Empty,
-}
+pub trait ByteArray: Default + Debug + Clone + Hash + DerefMut<Target = [u8]> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
  * Copyright (c) 2017 Maxwell Duzen, Ammon Smith
  *
  * striking-db is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 2 of
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2 of
  * the License, or (at your option) any later version.
  *
  * striking-db is distributed in the hope that it will be useful,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@ extern crate cfg_if;
 
 #[macro_use]
 extern crate lazy_static;
-
 extern crate lru_time_cache;
 extern crate num_cpus;
 extern crate parking_lot;

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -228,12 +228,10 @@ impl Volume {
     pub fn stats(&self) -> Stats {
         let mut total_stats = Stats::default();
 
-        self.0.rent(|strands| {
-            for ref strand in strands.iter() {
-                let guard = strand.read();
-                let stats = guard.stats.lock();
-                total_stats += stats.clone();
-            }
+        self.0.rent(|strands| for ref strand in strands.iter() {
+            let guard = strand.read();
+            let stats = guard.stats.lock();
+            total_stats += stats.clone();
         });
 
         total_stats


### PR DESCRIPTION
Originally this was going to use `thread_local!`, but it didn't work so well with how we structure our items.
So instead, I'm just merging the improvements I made to the buffers.