### PR TITLE
Make "Device" a trait instead of struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ stable_deref_trait = "1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.9"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.2"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -36,10 +36,6 @@ impl ReadCache {
         ReadCache(RwLock::new(LruCache::with_capacity(items)))
     }
 
-    pub fn key_exists(&self, key: &[u8]) -> bool {
-        self.0.read().contains_key(key)
-    }
-
     pub fn insert(&self, key: &[u8], val: &[u8]) -> Option<Box<[u8]>> {
         self.0.write().insert(
             Vec::from(key).into_boxed_slice(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -60,6 +60,7 @@ impl ReadCache {
         self.0.write().remove(key)
     }
 
+    #[allow(unused)]
     pub fn clear(&self) {
         self.0.write().clear();
     }

--- a/src/deleted.rs
+++ b/src/deleted.rs
@@ -42,10 +42,6 @@ impl Deleted {
         assert!(!exists, "Deleted item already tracked");
     }
 
-    pub fn count(&self) -> usize {
-        self.0.read().len()
-    }
-
     pub fn get_mut(&mut self) -> &mut DeletedSet {
         self.0.get_mut()
     }

--- a/src/device/memory.rs
+++ b/src/device/memory.rs
@@ -28,7 +28,7 @@ pub struct Memory(RwLock<Box<[u8]>>, u64);
 
 impl Memory {
     pub fn new(bytes: usize) -> Self {
-        let buffer = Vec::with_capacity(bytes).into_boxed_slice();
+        let buffer = vec![0; bytes].into_boxed_slice();
         Memory(RwLock::new(buffer), bytes as u64)
     }
 }

--- a/src/device/memory.rs
+++ b/src/device/memory.rs
@@ -40,7 +40,7 @@ impl Device for Memory {
     }
 
     #[inline]
-    fn block(&self) -> bool {
+    fn block_device(&self) -> bool {
         false
     }
 

--- a/src/device/memory.rs
+++ b/src/device/memory.rs
@@ -1,5 +1,5 @@
 /*
- * device/windows.rs
+ * device/memory.rs
  *
  * striking-db - Persistent key/value store for SSDs.
  * Copyright (c) 2017 Maxwell Duzen, Ammon Smith
@@ -19,14 +19,19 @@
  *
  */
 
-// TODO
-
-use super::Device;
+use super::{Device, Result};
 
 #[derive(Debug)]
-pub struct Ssd;
+pub struct Memory(Box<[u8]>);
 
-impl Device for Ssd {
+impl Memory {
+    pub fn new(bytes: usize) -> Self {
+        let buffer = Vec::with_capacity(bytes).into_boxed_slice();
+        Memory(buffer)
+    }
+}
+
+impl Device for Memory {
     fn capacity(&self) -> u64 {
         unimplemented!();
     }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -37,7 +37,7 @@ cfg_if! {
 
 pub trait Device: Debug {
     fn capacity(&self) -> u64;
-    fn block(&self) -> bool;
+    fn block_device(&self) -> bool;
     fn read(&self, off: u64, buf: &mut [u8]) -> Result<()>;
     fn write(&self, off: u64, buf: &[u8]) -> Result<()>;
     fn trim(&self, off: u64, len: u64) -> Result<()>;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -19,14 +19,49 @@
  *
  */
 
+use std::fmt::Debug;
+use super::*;
+
+mod memory;
+pub use self::memory::Memory;
+
 cfg_if! {
     if #[cfg(unix)] {
         mod unix;
-        pub use self::unix::Device;
+        pub use self::unix::Ssd;
     } else if #[cfg(windows)] {
         mod windows;
-        pub use self::windows::Device;
+        pub use self::windows::Ssd;
     }
 }
 
-use super::*;
+pub trait Device: Debug {
+    fn capacity(&self) -> u64;
+    fn block(&self) -> bool;
+    fn read(&self, off: u64, buf: &mut [u8]) -> Result<()>;
+    fn write(&self, off: u64, buf: &[u8]) -> Result<()>;
+    fn trim(&self, off: u64, len: u64) -> Result<()>;
+}
+
+#[inline(always)]
+fn check_read(dev: &Device, off: u64, buf: &[u8]) {
+    let len = buf.len() as u64;
+    assert_eq!(off % PAGE_SIZE64, 0, "Offset not a multiple of the page size");
+    assert_eq!(len % PAGE_SIZE64, 0, "Length not a multiple of the page size");
+    assert!(off + len < dev.capacity(), "Read is out of bounds");
+}
+
+#[inline(always)]
+fn check_write(dev: &Device, off: u64, buf: &[u8]) {
+    let len = buf.len() as u64;
+    assert_eq!(off % PAGE_SIZE64, 0, "Offset not a multiple of the page size");
+    assert_eq!(len % PAGE_SIZE64, 0, "Length not a multiple of the page size");
+    assert!(off + len < dev.capacity(), "Write is out of bounds");
+}
+
+#[inline(always)]
+fn check_trim(dev: &Device, off: u64, len: u64) {
+    assert_eq!(off % TRIM_SIZE64, 0, "Offset not a multiple of the trim size");
+    assert_eq!(len % TRIM_SIZE64, 0, "Length not a multiple of the trim size");
+    assert!(off + len < dev.capacity(), "Trim is out of bounds");
+}

--- a/src/device/windows.rs
+++ b/src/device/windows.rs
@@ -21,17 +21,42 @@
 
 // TODO
 
-use super::Device;
+use std::fs::File;
+use std::os::windows::prelude::*;
+use super::{Device, Result};
 
 #[derive(Debug)]
-pub struct Ssd;
+pub struct Ssd {
+    file: File,
+    capacity: u64,
+    block: bool,
+}
 
-impl Device for Ssd {
-    fn capacity(&self) -> u64 {
+impl Ssd {
+    fn get_metadata(file: &mut File) -> Result<(u64, bool)> {
+        let metadata = file.metadata()?;
         unimplemented!();
     }
 
-    fn block(&self) -> bool {
+    pub fn open(mut file: File) -> Result<Self> {
+        let (capacity, block) = Self::get_metadata()?;
+
+        Ok(Ssd {
+            file: file,
+            capacity: capacity,
+            block: block,
+        })
+    }
+}
+
+impl Device for Ssd {
+    #[inline]
+    fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    #[inline]
+    fn block_device(&self) -> bool {
         unimplemented!();
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -22,7 +22,6 @@
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
-use std::sync::Arc;
 use std::thread;
 use super::{MAX_KEY_LEN, FilePointer};
 
@@ -48,6 +47,7 @@ impl<'i, 'k> IndexEntryGuard<'i, 'k> {
     }
 
     #[inline]
+    #[allow(unused)]
     pub fn key(&self) -> &[u8] {
         self.key
     }
@@ -64,7 +64,7 @@ impl<'i, 'k> Drop for IndexEntryGuard<'i, 'k> {
         let mut map = index.write();
 
         {
-            let mut tuple = map.get_mut(self.key).expect("Locked entry is now empty");
+            let tuple = map.get_mut(self.key).expect("Locked entry is now empty");
             let (ref mut ptr, ref mut locked) = *tuple;
 
             if let Some(new_ptr) = self.value {
@@ -124,7 +124,7 @@ impl Index {
         // None case, but the borrow checker thinks
         // we already have a mutable reference to
         // "map" because of get_mut().
-        if let Some(mut tuple) = map.get_mut(key) {
+        if let Some(tuple) = map.get_mut(key) {
             let (ptr, ref mut locked) = *tuple;
             if *locked {
                 return None;
@@ -140,10 +140,6 @@ impl Index {
         }
 
         Some(IndexEntryGuard::new(&self.0, key.clone(), value))
-    }
-
-    pub fn count(&self) -> usize {
-        self.0.read().len()
     }
 
     pub fn get_mut(&mut self) -> &mut IndexTree {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,6 @@
  *
  */
 
-// FIXME: remove in final version, this is just here so
-// `chargo check`ing doesn't flood the terminal with warnings
-// about unused code
-#![allow(dead_code)]
-#![allow(unused)]
-
 extern crate capnp;
 
 #[macro_use]
@@ -52,10 +46,12 @@ cfg_if! {
 
 /* Generated sources */
 mod build {
+    #![allow(unused)]
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
 mod serial_capnp {
+    #![allow(unused)]
     include!(concat!(env!("OUT_DIR"), "/serial_capnp.rs"));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,15 @@ extern crate parking_lot;
 extern crate rental;
 extern crate stable_deref_trait;
 
-#[cfg(unix)]
-#[macro_use]
-extern crate nix;
+/* Platform-specific dependencies */
+cfg_if! {
+    if #[cfg(unix)] {
+        #[macro_use]
+        extern crate nix;
+    } else if #[cfg(windows)] {
+        extern crate winapi;
+    }
+}
 
 /* Generated sources */
 mod build {

--- a/src/serial/header.rs
+++ b/src/serial/header.rs
@@ -19,17 +19,16 @@
  *
  */
 
-use capnp::message::{Builder, Reader, ReaderOptions};
+use capnp::message::{Builder, ReaderOptions};
 use capnp::serialize_packed;
 use self::rentals::{VolumeHeaderRental, StrandHeaderRental};
 use serial_capnp::{self, strand_header, volume_header};
 use std::fmt;
-use std::io::{Read, Write};
 use super::alloc::PageAllocator;
 use super::buffer::Page;
 use super::stats::Stats;
 use super::strand::Strand;
-use super::{MIN_STRANDS, PAGE_SIZE, PAGE_SIZE64, VERSION, Error, FilePointer, Result};
+use super::{MIN_STRANDS, PAGE_SIZE64, VERSION, Error, FilePointer, Result};
 
 rental! {
     mod rentals {
@@ -97,6 +96,7 @@ impl VolumeHeader {
         Ok(Self::new(strands, state_ptr))
     }
 
+    #[allow(unused)]
     pub fn write(self, page: &mut Page) -> Result<()> {
         let mut slice = &mut page[..];
         serialize_packed::write_message(&mut slice, &*self.0.into_head())?;
@@ -122,10 +122,12 @@ impl VolumeHeader {
         })
     }
 
+    #[allow(unused)]
     pub fn set_strands(&mut self, strands: u16) {
         self.0.rent_mut(|message| message.set_strands(strands));
     }
 
+    #[allow(unused)]
     pub fn set_state_ptr(&mut self, state_ptr: Option<FilePointer>) {
         self.0.rent_mut(|message| {
             message.set_state_ptr(state_ptr.unwrap_or(0))
@@ -211,10 +213,12 @@ impl StrandHeader {
         Ok(())
     }
 
+    #[allow(unused)]
     pub fn get_id(&self) -> u16 {
         self.0.rent(|message| message.borrow_as_reader().get_id())
     }
 
+    #[allow(unused)]
     pub fn get_capacity(&self) -> u64 {
         self.0.rent(
             |message| message.borrow_as_reader().get_capacity(),
@@ -227,6 +231,7 @@ impl StrandHeader {
         )
     }
 
+    #[allow(unused)]
     pub fn get_stats(&self) -> Stats {
         self.0.rent(|message| {
             let reader = message.borrow_as_reader();
@@ -243,18 +248,22 @@ impl StrandHeader {
         })
     }
 
+    #[allow(unused)]
     pub fn set_id(&mut self, id: u16) {
         self.0.rent_mut(|message| message.set_id(id))
     }
 
+    #[allow(unused)]
     pub fn set_capacity(&mut self, capacity: u64) {
         self.0.rent_mut(|message| message.set_capacity(capacity))
     }
 
+    #[allow(unused)]
     pub fn set_offset(&mut self, offset: u64) {
         self.0.rent_mut(|message| message.set_offset(offset))
     }
 
+    #[allow(unused)]
     pub fn set_stats(&mut self, stats: &Stats) {
         self.0.rent_mut(|message| {
             message.set_stats_read_bytes(stats.read_bytes);

--- a/src/serial/io.rs
+++ b/src/serial/io.rs
@@ -26,7 +26,7 @@ use super::error::Error;
 use super::header::StrandHeader;
 use super::strand::Strand;
 use super::utils::{align, block_align};
-use super::{PAGE_SIZE, PAGE_SIZE64, TRIM_SIZE, TRIM_SIZE64, FilePointer};
+use super::{PAGE_SIZE, PAGE_SIZE64, TRIM_SIZE, FilePointer};
 
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
 enum BufferStatus {

--- a/src/serial/item.rs
+++ b/src/serial/item.rs
@@ -19,7 +19,7 @@
  *
  */
 
-use capnp::message::{Builder, Reader, ReaderOptions};
+use capnp::message::{Builder, ReaderOptions};
 use capnp::serialize_packed;
 use std::cmp::min;
 use std::io::Write;
@@ -54,6 +54,7 @@ impl<'a> ReadContext<'a> {
     }
 
     #[inline]
+    #[allow(unused)]
     pub fn copy_key(&self, key_buf: &mut [u8]) -> Result<usize> {
         let slice = self.0.get_key()?;
         Ok(Self::copy_slice(slice, key_buf))

--- a/src/store.rs
+++ b/src/store.rs
@@ -228,14 +228,14 @@ impl<'a> Store<'a> {
         self.volume.stats()
     }
 
-    #[inline]
-    pub fn items(&self) -> usize {
-        self.index.count()
-    }
-
     // Helpers
-    fn lookup_item(&self, strand: &Strand, ptr: FilePointer, val: &mut [u8]) -> Result<usize> {
-        read_item(strand, ptr, |ctx| ctx.copy_val(val))
+    fn lookup_item(&self, strand: &Strand, ptr: FilePointer, buf: &mut [u8]) -> Result<usize> {
+        read_item(strand, ptr, |ctx| {
+            let key = ctx.key()?;
+            let val = ctx.val()?;
+            self.cache.insert(key, val);
+            ctx.copy_val(buf)
+        })
     }
 
     fn remove_item(&self, key: &[u8], ptr: FilePointer) {

--- a/src/store.rs
+++ b/src/store.rs
@@ -27,7 +27,7 @@ use serial::{DatastoreState, read_item, write_item};
 use stats::Stats;
 use std::fs::File;
 use strand::Strand;
-use super::device::{Device, Ssd, Memory};
+use super::device::{Ssd, Memory};
 use super::error::Error;
 use super::volume::Volume;
 use super::{MAX_KEY_LEN, MAX_VAL_LEN, FilePointer, Result};
@@ -248,7 +248,7 @@ impl<'a> Store<'a> {
         let deleted = self.deleted.get_mut();
 
         self.volume.write(|strand| {
-            let state = DatastoreState::new(index, deleted);
+            let state = DatastoreState::new(index, deleted)?;
             state.write(strand)
         })
     }

--- a/src/strand.rs
+++ b/src/strand.rs
@@ -24,8 +24,7 @@ use device::Device;
 use parking_lot::Mutex;
 use serial::StrandHeader;
 use stats::Stats;
-use std::ops::Deref;
-use super::{PAGE_SIZE, PAGE_SIZE64, FilePointer, Result};
+use super::{PAGE_SIZE64, FilePointer, Result};
 
 #[derive(Debug)]
 pub struct Strand<'d> {
@@ -72,7 +71,7 @@ impl<'d> Strand<'d> {
             } else {
                 // Format strand
                 let header = StrandHeader::new(id, capacity);
-                header.write(&mut page);
+                header.write(&mut page)?;
                 device.write(0, &page[..])?;
 
                 PAGE_SIZE64
@@ -132,7 +131,7 @@ impl<'d> Strand<'d> {
     pub fn write_metadata(&mut self) -> Result<()> {
         let mut page = Page::default();
         let header = StrandHeader::from(self);
-        header.write(&mut page);
+        header.write(&mut page)?;
         self.write(0, &page[..])
     }
 
@@ -162,6 +161,7 @@ impl<'d> Strand<'d> {
         self.device.write(self.start + off, buf)
     }
 
+    #[allow(unused)]
     pub fn trim(&self, off: u64, len: u64) -> Result<()> {
         debug_assert!(off > self.capacity, "Offset is outside strand");
         debug_assert!(len > self.start + self.capacity, "Length outside of strand");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,28 +27,6 @@ pub fn align(off: u64) -> u64 {
 }
 
 #[inline]
-pub fn align_up(off: u64) -> u64 {
-    let mut align_off = align(off);
-
-    if align_off != off {
-        align_off += 1;
-    }
-
-    align_off
-}
-
-#[inline]
 pub fn block_align(off: u64) -> u64 {
     (off / TRIM_SIZE64) * TRIM_SIZE64
-}
-
-#[inline]
-pub fn block_align_up(off: u64) -> u64 {
-    let mut align_off = align(off);
-
-    if align_off != off {
-        align_off += 1;
-    }
-
-    align_off
 }

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -25,7 +25,7 @@ use device::Device;
 use error::Error;
 use index::Index;
 use num_cpus;
-use options::{OpenMode, OpenOptions};
+use options::OpenOptions;
 use parking_lot::RwLock;
 use self::rentals::VolumeRental;
 use serial::{DatastoreState, VolumeHeader};
@@ -34,7 +34,7 @@ use std::cmp::{Ordering, min};
 use std::time::Duration;
 use std::u16;
 use strand::Strand;
-use super::{MIN_STRANDS, PAGE_SIZE, PAGE_SIZE64, FilePointer, Result};
+use super::{MIN_STRANDS, PAGE_SIZE64, FilePointer, Result};
 use utils::align;
 
 #[derive(Debug)]
@@ -74,7 +74,7 @@ impl VolumeOpen {
         })
     }
 
-    fn read(dev: &Device, options: &OpenOptions) -> Result<Self> {
+    fn read(dev: &Device) -> Result<Self> {
         let mut page = Page::default();
         dev.read(0, &mut page[..])?;
 
@@ -128,8 +128,8 @@ impl<'a> Volume<'a> {
 
             // Collect options
             let open = match options.mode {
-                Read => VolumeOpen::read(device, options)?,
                 Create | Truncate => VolumeOpen::new(device, options)?,
+                Read => VolumeOpen::read(device)?,
             };
 
             if !options.reindex {

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -120,7 +120,7 @@ impl VolumeState {
 pub struct Volume(VolumeRental);
 
 impl Volume {
-    pub fn open(device: Device, options: &OpenOptions) -> Result<(Self, VolumeState)> {
+    pub fn open<D: Device>(device: D, options: &OpenOptions) -> Result<(Self, VolumeState)> {
         use rental::TryNewError;
 
         let mut state_ptr = None;


### PR DESCRIPTION
This also creates the `Memory` struct, which implements `Device` and allows you to create a temporary, in-memory datastore.